### PR TITLE
Batch mode and cosmetic changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ example*.json
 builder.sh
 build
 debug.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ xcshowmap -api-url "<https://api.f5xc.com>" -token "my_token" -namespace "my-nam
 ### Mermaid Diagram Output
 
 ```sql
-graph LR;
+graph TB;
     User -->|SNI| LoadBalancer;
     LoadBalancer -->|dummy.myedgedemo.com| dummy.myedgedemo.com;
     dummy.myedgedemo.com --> ServicePolicies;

--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ graph LR;
 
 To visualize the diagram, copy the Mermaid output into an online Mermaid editor like: 🔗 [Mermaid Live Editor](https://mermaid.live/)
 
+You can also install mermaid cli and bulk convert to svg if required
+
+e.g.
+```bash
+npm install -g @mermaid-js/mermaid-cli 
+for i in $(find . -name "*.mmd" -print)
+do
+mmdc -i $i -o ${i:r}.svg 
+done
+```
+
 ### Features
 
 - Generates Service Flow from F5 XC API

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ xcshowmap -api-url <API_URL> -token <TOKEN> -namespace <NAMESPACE> -load-balance
 | `-namespace`   | Namespace of the Load Balancer or all          | ✅ Yes   |
 | `-load-balancer` | Load Balancer name to inspect or all           | ✅ Yes   |
 | `-debug`       | Prints raw JSON API responses for debugging    | ❌ No    |
-| `-batch`       | Save output as raw mermaid file under          | ❌ No    |
-|                | a <<namespce>>/<<loadbalancer>>.mmd structure  ||
+| `-batch`       | Save output as raw mermaid file under <br> a *namespace*/*loadbalancer*.mmd structure        | ❌ No    |
+
 
 ## Example Usage
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ xcshowmap -api-url <API_URL> -token <TOKEN> -namespace <NAMESPACE> -load-balance
 |----------------|------------------------------------------------|----------|
 | `-api-url`     | Base API URL to query F5 XC                    | ✅ Yes   |
 | `-token`       | API Token for authentication                   | ✅ Yes   |
-| `-namespace`   | Namespace of the Load Balancer                 | ✅ Yes   |
+| `-namespace`   | Namespace of the Load Balancer or all          | ✅ Yes   |
 | `-load-balancer` | Load Balancer name to inspect or all           | ✅ Yes   |
 | `-debug`       | Prints raw JSON API responses for debugging    | ❌ No    |
+| `-batch`       | Save output as raw mermaid file under          | ❌ No    |
+|                | a <<namespce>>/<<loadbalancer>>.mmd structure  ||
 
 ## Example Usage
 
@@ -54,6 +56,14 @@ xcshowmap -api-url "<https://example.api.f5.com>" -token "your_api_token" -names
 ```
 
 (Debug mode prints raw API responses for troubleshooting.)
+
+### Batch Mode
+
+```bash
+xcshowmap -api-url "<https://example.api.f5.com>" -token "your_api_token" -namespace "your-namespace" -load-balancer "all" -batch
+```
+
+(Batch mode will output raw mermaid output in a folder structure across an entire namespace or an entire tenant)
 
 ### Example Output
 
@@ -157,7 +167,7 @@ graph LR;
 
 To visualize the diagram, copy the Mermaid output into an online Mermaid editor like: 🔗 [Mermaid Live Editor](https://mermaid.live/)
 
-You can also install mermaid cli and bulk convert to svg if required
+If you have used batch mode you can also install mermaid cli and bulk convert to svg.
 
 e.g.
 ```bash

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ xcshowmap -api-url <API_URL> -token <TOKEN> -namespace <NAMESPACE> -load-balance
 xcshowmap -api-url "<https://example.api.f5.com>" -token "your_api_token" -namespace "your-namespace" -load-balancer "your-load-balancer"
 ```
 
-### All Namespace LBs
+### To list all Namespace LBs
 ```bash
 xcshowmap -api-url "<https://example.api.f5.com>" -token "your_api_token" -namespace "your-namespace" -load-balancer "all"
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ xcshowmap -api-url <API_URL> -token <TOKEN> -namespace <NAMESPACE> -load-balance
 | `-api-url`     | Base API URL to query F5 XC                    | ✅ Yes   |
 | `-token`       | API Token for authentication                   | ✅ Yes   |
 | `-namespace`   | Namespace of the Load Balancer                 | ✅ Yes   |
-| `-load-balancer` | Load Balancer name to inspect               | ✅ Yes   |
+| `-load-balancer` | Load Balancer name to inspect or all           | ✅ Yes   |
 | `-debug`       | Prints raw JSON API responses for debugging    | ❌ No    |
 
 ## Example Usage
@@ -40,6 +40,11 @@ xcshowmap -api-url <API_URL> -token <TOKEN> -namespace <NAMESPACE> -load-balance
 
 ```bash
 xcshowmap -api-url "<https://example.api.f5.com>" -token "your_api_token" -namespace "your-namespace" -load-balancer "your-load-balancer"
+```
+
+### All Namespace LBs
+```bash
+xcshowmap -api-url "<https://example.api.f5.com>" -token "your_api_token" -namespace "your-namespace" -load-balancer "all"
 ```
 
 ### Debug Mode

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ graph LR;
 ---
 title: F5 Distributed Cloud Load Balancer Service Flow
 ---
-graph LR;
+graph TB;
     User --> LoadBalancer;
     LoadBalancer["**Public Load Balancer**"];
     classDef certValid stroke:#01ba44,stroke-width:2px;
@@ -108,7 +108,7 @@ graph LR;
     domain_dummy-f5sa_myedgedemo_com --> ServicePolicies;
     domain_f5-dummy_myedgedemo_com --> ServicePolicies;
     subgraph ServicePolicies ["**Common Security Controls**"]
-        direction TB
+        direction LR
         sp_ns["Apply Namespace Service Policies"];
         mud["Malicious User Detection"];
     end


### PR DESCRIPTION
Not sure if you want all of this as some of it is personal preference I guess.

Added -batch flag to either dump all LBs in a specified namespace or all LBs in all namespaces. (hopefully the platform prevents you from creating a namespace or LB called "all"!
In batch mode the files are created in a namespace/lbname structure without the markdown header/trailer. (feels like this ought to be an option as I guess you might want to upload the content directly back to GitHub or something but I built it for the bulk sag use case to upload to our Sharepoint.

I also changed the orientation to go vertically as it seemed to flow better with a larger number of pools.
I changed pool members to fill in a single flow chart icon as a pool with 20 members just looked hideous.

Animated the arrows just for a bit of fun.
Made the WAF box red filled if there is no WAF and it is a public LB - That is a matter of opinion as there could be a service policy that mitigates such foolishness but it seemed like a sensible thing to call out.

Having said that keen to try to make sure I don't have to maintain a separate fork.
 